### PR TITLE
Json attribute prop createandmint

### DIFF
--- a/src/models/hedera.interface.ts
+++ b/src/models/hedera.interface.ts
@@ -19,7 +19,7 @@ export interface NFTDto {
     supply: number;
     /* Custom Royalty Fees  */
     customRoyaltyFee: CustomFee | null;
-    /* Custom JSON attributes storage URI */
+    /* Custom JSON of attributes */
     customNFTJson: Object | null;
 }
 
@@ -35,8 +35,7 @@ export interface CreateNFT {
     category: CategoryNFT,
     cid: string,
     supply: number,
-    customFee: CustomFee | null,
-    customNFTJson: string | null
+    customFee: CustomFee | null
 }
 
 export interface Fees {

--- a/src/models/hedera.interface.ts
+++ b/src/models/hedera.interface.ts
@@ -19,6 +19,8 @@ export interface NFTDto {
     supply: number;
     /* Custom Royalty Fees  */
     customRoyaltyFee: CustomFee | null;
+    /* Custom JSON attributes storage URI */
+    customNFTJson: Object | null;
 }
 
 export interface NftCreated {
@@ -26,6 +28,15 @@ export interface NftCreated {
     txId: string;
     tokenId: string;
     nftIds: Array<string>;
+}
+
+export interface CreateNFT { 
+    name: string, creator: string,
+    category: CategoryNFT,
+    cid: string,
+    supply: number,
+    customFee: CustomFee | null,
+    customNFTJson: string | null
 }
 
 export interface Fees {

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -65,7 +65,7 @@ export class ClientNFT {
      */
     async createAndMint(createNFTDto: NFTDto): Promise<NftCreated> {
         let cid;
-        if (!createNFTDto.media || !createNFTDto.name) {
+        if ((!createNFTDto.media && !createNFTDto.customNFTJson) || !createNFTDto.name) {
             Logger.error('name and media parameters must be defined when calling this method... Check the Usage on https://www.npmjs.com/package/@xact-wallet-sdk/nft#usage');
             return Promise.reject('Please define at least a Media and a Name for your NFT !');
         }
@@ -75,7 +75,9 @@ export class ClientNFT {
             await this.hederaSdk.checkBalance();
             /* Storing the Media */
             Logger.info('Saving the media on FileCoin...');
-            cid = await storeNFT({token: this.nftStorageApiKey, ...createNFTDto});
+
+            const nftStoreObj = {token: this.nftStorageApiKey, ...createNFTDto};
+            cid = await storeNFT(nftStoreObj);
 
             /* Create the NFT */
             Logger.info('Creating the NFT on Hedera...');
@@ -85,7 +87,8 @@ export class ClientNFT {
                 category: createNFTDto.category,
                 supply: createNFTDto.supply,
                 cid,
-                customFee: createNFTDto.customRoyaltyFee
+                customFee: createNFTDto.customRoyaltyFee,
+                customNFTJson: createNFTDto.customNFTJson,
             });
             Logger.debug('Your NFT will be available soon on', res.url);
             return res;

--- a/src/nft.ts
+++ b/src/nft.ts
@@ -87,8 +87,7 @@ export class ClientNFT {
                 category: createNFTDto.category,
                 supply: createNFTDto.supply,
                 cid,
-                customFee: createNFTDto.customRoyaltyFee,
-                customNFTJson: createNFTDto.customNFTJson,
+                customFee: createNFTDto.customRoyaltyFee
             });
             Logger.debug('Your NFT will be available soon on', res.url);
             return res;

--- a/src/sdk-hedera/hedera.sdk.ts
+++ b/src/sdk-hedera/hedera.sdk.ts
@@ -8,7 +8,7 @@ import {
     TokenType
 } from '@hashgraph/sdk';
 import axios from 'axios';
-import {Fees, HederaAccount, NftCreated, HederaEnviroment, CustomFee, CategoryNFT} from '../models/hedera.interface';
+import {Fees, HederaAccount, NftCreated, HederaEnviroment, CreateNFT} from '../models/hedera.interface';
 import Logger from 'js-logger';
 
 const HEDERA_CREATE_NFT_FEES = 1;
@@ -33,8 +33,8 @@ export class HederaSdk {
                         category,
                         cid,
                         supply,
-                        customFee
-                    }: { name: string, creator: string, category: CategoryNFT, cid: string, supply: number, customFee: CustomFee | null }): Promise<NftCreated> {
+                        customFee,
+                    }: CreateNFT): Promise<NftCreated> {
         try {
             /* Create a royalty fee */
             const customRoyaltyFee = [];
@@ -80,7 +80,6 @@ export class HederaSdk {
             for (let i = 0; i < supply; i++) {
                 mintTransaction.addMetadata(Buffer.from(JSON.stringify({name, creator, category, supply})));
             }
-
             /* Sign with the supply private key of the token */
             const signTx = await mintTransaction.freezeWith(this.client).sign(supplyKey);
             /* Submit the transaction to a Hedera network */

--- a/src/sdk-storage/storage.sdk.ts
+++ b/src/sdk-storage/storage.sdk.ts
@@ -7,22 +7,23 @@ export async function storeNFT({
                                    description,
                                    creator,
                                    category,
-                                   media
+                                   media,
+                                   customNFTJson
                                }: NFTDto & { token: string }) {
-    return axios.post('https://nft.storage/api/upload', {
+    return axios.post('https://nft.storage/api/upload', customNFTJson ? customNFTJson :{
         name,
         description,
         creator,
         category,
         supply: 1,
-        photo: media
+        image: media,
     }, {
         headers: {
             common: {
                 Authorization: `Bearer ${token}`,
             },
         },
-    }).then((res) => {
+    }).then((res: any) => {
         return res.data.value.cid;
     });
 }

--- a/src/sdk-storage/storage.sdk.ts
+++ b/src/sdk-storage/storage.sdk.ts
@@ -16,7 +16,7 @@ export async function storeNFT({
         creator,
         category,
         supply: 1,
-        image: media,
+        image: media
     }, {
         headers: {
             common: {


### PR DESCRIPTION
I created the token below with this new updated createAndMint function. I think this is correct. I blended the JSON structure of ERC and what you showed me from greg. Let me know if this schema makes sense for PluarlNFT. 

https://testnet.dragonglass.me/hedera/tokens/0.0.2728872

Callback:
nftIds: Array(10)
0: "1@0.0.2728872"
1: "2@0.0.2728872"
2: "3@0.0.2728872"
3: "4@0.0.2728872"
4: "5@0.0.2728872"
5: "6@0.0.2728872"
6: "7@0.0.2728872"
7: "8@0.0.2728872"
8: "9@0.0.2728872"
9: "10@0.0.2728872"
tokenId: "0.0.2728872"
txId: "0.0.1960117@1633291343.872618977"
url: "https://cloudflare-ipfs.com/ipfs/bafkreidwgm6jkeudp7wdbx4pnz3pn54b2ak6zzolll7vj3ltqdzfsly4ke"